### PR TITLE
Fixed sleep crashing the script when running it in some locales.

### DIFF
--- a/zram-swap.sh
+++ b/zram-swap.sh
@@ -143,7 +143,7 @@ _regex_match() { echo "$1" | grep -Eq -- "$2" > /dev/null 2>&1; }
 # usage: calc (int; precision := 0) (str; expr to evaluate)
 calc() {
   _regex_match "$1" '^[[:digit:]]+$' && { n="$1" && shift; } || n=0
-  awk "BEGIN{printf \"%.${n}f\", $*}"
+  LC_NUMERIC=C awk "BEGIN{printf \"%.${n}f\", $*}"
 }
 
 err() { echo "Err $*" >&2; }


### PR DESCRIPTION
awk, and by extension the calc function, both return a number with a decimal separator defined by LC_NUMERIC.
In locales such as France and Germany, this meant calc would return a comma separated decimal.
This caused the script to fail when reaching the sleep command, because it can only parse dot separated decimals.
To fix this, awk in the calc function is forced to use LC_NUMERIC=C (portable locale), which does use dot separated decimals.