### PR TITLE
add SET_CONFIG_UPDATE for autorun settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ _zram_algorithm="lzo-rle"
 Remember that the ZRAM device size references uncompressed data, real memory
 utilization should be ~2-3x smaller than the zram device size due to compression.
 
+If you run `install.sh` in a automatic script, like ansible, use `SET_CONFIG_UPDATE=[(I)nstall, (K)eep] ./install.sh` to skip the interactive-prompt.
+
 #### A quick note RE: compression algorithms:
 
 The default configuration using lz4 should work well for most people. lzo may

--- a/install.sh
+++ b/install.sh
@@ -65,8 +65,15 @@ _install() {
       echo "Install package default configuration? Local config will be saved as /etc/default/zram-swap.oldconfig"
       while true; do
         echo "(I)nstall package default / (K)eep local configuration / View (D)iff"
-        printf "[i/k/d]: "
-        read yn
+        set +u
+        if [ -n "$SET_CONFIG_UPDATE" ]; then
+          yn=$SET_CONFIG_UPDATE
+          unset SET_CONFIG_UPDATE
+        else
+          printf "[i/k/d]: "
+          read yn
+        fi
+        set -u
         case "$yn" in
           [Ii]*)
             echo "Installing package default ..."
@@ -76,6 +83,7 @@ _install() {
             ;;
           [Kk]*) break ;;
           [Dd]*) printf "%s\n\n" "$configdiff" ;;
+	  *) ;;
         esac
       done
     fi


### PR DESCRIPTION
the option allows user to use the install.sh script in autorun setups, like ansible or as a part of other automation.

`SET_CONFIG_UPDATE=k ./install.sh`